### PR TITLE
Use predicate to test for session handle presence

### DIFF
--- a/lib/Thrift/API/HiveClient2.pm
+++ b/lib/Thrift/API/HiveClient2.pm
@@ -225,6 +225,7 @@ has _session_handle => (
     },
     lazy    => 1,
     builder => '_build_session_handle',
+    predicate => '_has_session_handle',
 );
 
 sub _build_session_handle {
@@ -484,7 +485,7 @@ sub DEMOLISH {
 
     $self->_cleanup_previous_operation;
 
-    if ( $self->_session_handle ) {
+    if ( $self->_has_session_handle ) {
         $self->_client->CloseSession(
             Thrift::API::HiveClient2::TCloseSessionReq->new(
                 { sessionHandle => $self->_session_handle, }


### PR DESCRIPTION
As it's a lazy property, it makes no sense to check it directly. This was causing exceptions in `DESTROY` when client failed to connect initially. And such an exception leads to an uncoditional `(in cleanup)` warnings issued by perl runtime.