### PR TITLE
Enable SSL support

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,9 @@ Revision history for Thrift-API-HiveClient2
 
 {{$NEXT}}
 
+0.025 2024-06-25 
+    Enable SSL support
+
 0.024 2019-02-12 BURAK
     Include the patch by Alexey Lebedeff
         "Use predicate to test for session handle presence".

--- a/Changes
+++ b/Changes
@@ -2,9 +2,6 @@ Revision history for Thrift-API-HiveClient2
 
 {{$NEXT}}
 
-0.025 2024-06-25 
-    Enable SSL support
-
 0.024 2019-02-12 BURAK
     Include the patch by Alexey Lebedeff
         "Use predicate to test for session handle presence".

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Thrift::API::HiveClient2 - Perl to HiveServer2 Thrift API wrapper
 
 # VERSION
 
-version 0.024
+version 0.025
 
 # METHODS
 
@@ -33,6 +33,10 @@ Kerberos principal. Default is not set. See the ["WARNING"](#warning) section.
 ### sasl
 
 Enables authentication. Default is not set. See the ["WARNING"](#warning) section.
+
+### use_ssl
+
+uses Thrift::SSLSocket if enabled by setting 1. By default set to 0 and uses Thrift::Socket
 
 ### timeout
 

--- a/lib/Thrift/API/HiveClient2.pm
+++ b/lib/Thrift/API/HiveClient2.pm
@@ -12,6 +12,7 @@ use List::MoreUtils 'zip';
 
 use Thrift;
 use Thrift::Socket;
+use Thrift::SSLSocket;
 use Thrift::BufferedTransport;
 
 # Protocol loading is done dynamically later.
@@ -65,6 +66,11 @@ has port => (
     default => sub {10_000},
 );
 has sasl => (
+    is      => 'ro',
+    default => 0,
+);
+
+has use_ssl => (
     is      => 'ro',
     default => 0,
 );
@@ -126,7 +132,16 @@ sub _set_sasl {
 sub BUILD {
     my $self = shift;
 
-    $self->_set_socket( Thrift::Socket->new( $self->host, $self->port ) )
+    my $thrift_socket;
+    
+    if( $self->use_ssl ) {
+     $thrift_socket = Thrift::SSLSocket->new( $self->host, $self->port );
+    }
+    else {
+     $thrift_socket = Thrift::Socket->new( $self->host, $self->port );
+    }
+
+    $self->_set_socket( $thrift_socket )
         unless $self->_socket;
     $self->_socket->setRecvTimeout( $self->timeout * 1000 );
 
@@ -551,6 +566,10 @@ Kerberos principal. Default is not set. See the L</WARNING> section.
 =head3 sasl
 
 Enables authentication. Default is not set. See the L</WARNING> section.
+
+=head3 use_ssl
+
+uses Thrift::SSLSocket if enabled by setting 1. By default set to 0 and uses Thrift::Socket
 
 =head3 timeout
 


### PR DESCRIPTION
HiveClient2 module doesn't have support for ssl protocol  for thrift socket. 
Thrift::Socket module doesn't have support for ssl and there is separate module Thrift::SSLSocket which supports SSL. 